### PR TITLE
DRY has_child_count methods and remove TODO

### DIFF
--- a/lib/honeydew/device_matchers.rb
+++ b/lib/honeydew/device_matchers.rb
@@ -37,19 +37,20 @@ module Honeydew
       perform_assertion :is_button_present, :text => button_text
     end
 
-    # TODO: Look for a better way to express these similar looking matchers
-    def has_child_count?(parent_element_description, child_element_description, child_count)
-      perform_assertion :is_child_count_equal_to,
-        :parent_description => parent_element_description,
-         :child_description => child_element_description,
-         :child_count => child_count
+    def has_child_count? parent_description, child_description, child_count
+      child_count_assertion 'equal_to', parent_description, child_description, child_count
     end
 
-    def has_child_count_greater_than?(parent_element_description, child_element_description, child_count)
-      perform_assertion :is_child_count_greater_than,
-        :parent_description => parent_element_description,
-         :child_description => child_element_description,
-         :child_count => child_count
+    def has_child_count_greater_than? parent_description, child_description, child_count
+      child_count_assertion 'greater_than', parent_description, child_description, child_count
+    end
+
+    def child_count_assertion count_type, parent_description, child_description, child_count
+      assertion_type = "is_child_count_#{count_type}".to_sym
+      perform_assertion assertion_type,
+                        :parent_description => parent_description,
+                        :child_description => child_description,
+                        :child_count => child_count
     end
 
     def has_element_with_nested_text?(parent_description, child_text)


### PR DESCRIPTION
I created a helper method that pulls out the options and generates the correct assertion. This removes some duplicate code.
